### PR TITLE
How to run oft-solana example

### DIFF
--- a/examples/oft-solana/contracts/MyOFT.sol
+++ b/examples/oft-solana/contracts/MyOFT.sol
@@ -10,5 +10,7 @@ contract MyOFT is OFT {
         string memory _symbol,
         address _lzEndpoint,
         address _delegate
-    ) OFT(_name, _symbol, _lzEndpoint, _delegate) Ownable(_delegate) {}
+    ) OFT(_name, _symbol, _lzEndpoint, _delegate) Ownable(_delegate) {
+        _mint(msg.sender, 1000 ether);
+    }
 }

--- a/examples/oft-solana/deploy/MyOFT.ts
+++ b/examples/oft-solana/deploy/MyOFT.ts
@@ -36,8 +36,8 @@ const deploy: DeployFunction = async (hre) => {
     const { address } = await deploy(contractName, {
         from: deployer,
         args: [
-            'MyOFT', // name
-            'MOFT', // symbol
+            'WooTestOFT', // name
+            'WTOFT', // symbol
             endpointV2Deployment.address, // LayerZero's EndpointV2 address
             deployer, // owner
         ],

--- a/examples/oft-solana/hardhat.config.ts
+++ b/examples/oft-solana/hardhat.config.ts
@@ -61,7 +61,7 @@ const config: HardhatUserConfig = {
     networks: {
         'sepolia-testnet': {
             eid: EndpointId.SEPOLIA_V2_TESTNET,
-            url: process.env.RPC_URL_SEPOLIA || 'https://rpc.sepolia.org/',
+            url: 'https://eth-sepolia.g.alchemy.com/v2/-Z5IK5ZknQgG4obvaW3fCSA92G8-5CPE',
             accounts,
         },
         hardhat: {

--- a/examples/oft-solana/layerzero.config.ts
+++ b/examples/oft-solana/layerzero.config.ts
@@ -1,4 +1,5 @@
 import { EndpointId } from '@layerzerolabs/lz-definitions'
+import { ExecutorOptionType } from '@layerzerolabs/lz-v2-utilities'
 
 import type { OAppOmniGraphHardhat, OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
 
@@ -11,7 +12,7 @@ const sepoliaContract: OmniPointHardhat = {
 
 const solanaContract: OmniPointHardhat = {
     eid: EndpointId.SOLANA_V2_TESTNET,
-    address: '', // TODO update this with the OFTStore address.
+    address: 'FZL4iPCZm6QUcHNYz8Vfo5t9WNjbREjkuf6MT2RYu9Wq', // TODO update this with the OFTStore address.
 }
 
 const config: OAppOmniGraphHardhat = {
@@ -29,102 +30,102 @@ const config: OAppOmniGraphHardhat = {
             to: solanaContract,
             // TODO:  Here are some default settings that have been found to work well sending to Sepolia.  We suggest
             //  performing additional profiling to ensure they are correct for your use case.
-            // config: {
-            //     enforcedOptions: [
-            //         {
-            //             msgType: 1,
-            //             optionType: ExecutorOptionType.LZ_RECEIVE,
-            //             gas: 200000,
-            //             value: 2500000,
-            //         },
-            //         {
-            //             msgType: 2,
-            //             optionType: ExecutorOptionType.LZ_RECEIVE,
-            //             gas: 200000,
-            //             value: 2500000,
-            //         },
-            //         {
-            //             // Solana options use (gas == compute units, value == lamports)
-            //             msgType: 2,
-            //             optionType: ExecutorOptionType.COMPOSE,
-            //             index: 0,
-            //             gas: 0,
-            //             value: 0,
-            //         },
-            //     ],
-            // },
+            config: {
+                enforcedOptions: [
+                    {
+                        msgType: 1,
+                        optionType: ExecutorOptionType.LZ_RECEIVE,
+                        gas: 200000,
+                        value: 2500000,
+                    },
+                    {
+                        msgType: 2,
+                        optionType: ExecutorOptionType.LZ_RECEIVE,
+                        gas: 200000,
+                        value: 2500000,
+                    },
+                    {
+                        // Solana options use (gas == compute units, value == lamports)
+                        msgType: 2,
+                        optionType: ExecutorOptionType.COMPOSE,
+                        index: 0,
+                        gas: 0,
+                        value: 0,
+                    },
+                ],
+            },
         },
         {
             from: solanaContract,
             to: sepoliaContract,
             // TODO Here are some default settings that have been found to work well sending to Sepolia. We suggest
             //  performing additional profiling to ensure they are correct for your use case.
-            // config: {
-            //     sendLibrary: '7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH',
-            //     receiveLibraryConfig: {
-            //         receiveLibrary: '7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH',
-            //         gracePeriod: BigInt(0),
-            //     },
-            //     // Optional Receive Library Timeout for when the Old Receive Library Address will no longer be valid
-            //     // Note:  This configuring `receiveLibraryTimeoutConfig` using devtools is not currently available for Solana.
-            //     // receiveLibraryTimeoutConfig: {
-            //     //     lib: '0x0000000000000000000000000000000000000000',
-            //     //     expiry: BigInt(0),
-            //     // },
-            //     // Optional Send Configuration
-            //     // @dev Controls how the `from` chain sends messages to the `to` chain.
-            //     sendConfig: {
-            //         executorConfig: {
-            //             maxMessageSize: 10000,
-            //             // The configured Executor address.  Note, this is the executor PDA not the program ID.
-            //             executor: 'AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK',
-            //         },
-            //         ulnConfig: {
-            //             // // The number of block confirmations to wait on BSC before emitting the message from the source chain.
-            //             confirmations: BigInt(10),
-            //             // The address of the DVNs you will pay to verify a sent message on the source chain ).
-            //             // The destination tx will wait until ALL `requiredDVNs` verify the message.
-            //             requiredDVNs: [
-            //                 '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb', // LayerZero
-            //             ],
-            //             // The address of the DVNs you will pay to verify a sent message on the source chain ).
-            //             // The destination tx will wait until the configured threshold of `optionalDVNs` verify a message.
-            //             optionalDVNs: [],
-            //             // The number of `optionalDVNs` that need to successfully verify the message for it to be considered Verified.
-            //             optionalDVNThreshold: 0,
-            //         },
-            //     },
-            //     // Optional Receive Configuration
-            //     // @dev Controls how the `from` chain receives messages from the `to` chain.
-            //     receiveConfig: {
-            //         ulnConfig: {
-            //             // The number of block confirmations to expect from the `to` chain.
-            //             confirmations: BigInt(2),
-            //             // The address of the DVNs your `receiveConfig` expects to receive verifications from on the `from` chain ).
-            //             // The `from` chain's OApp will wait until the configured threshold of `requiredDVNs` verify the message.
-            //             requiredDVNs: [
-            //                 '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb', // LayerZero
-            //             ],
-            //             // The address of the DVNs you will pay to verify a sent message on the source chain ).
-            //             // The destination tx will wait until the configured threshold of `optionalDVNs` verify a message.
-            //             optionalDVNs: [],
-            //             // The number of `optionalDVNs` that need to successfully verify the message for it to be considered Verified.
-            //             optionalDVNThreshold: 0,
-            //         },
-            //     },
-            //     enforcedOptions: [
-            //         {
-            //             msgType: 1,
-            //             optionType: ExecutorOptionType.LZ_RECEIVE,
-            //             gas: 200000,
-            //         },
-            //         {
-            //             msgType: 2,
-            //             optionType: ExecutorOptionType.LZ_RECEIVE,
-            //             gas: 200000,
-            //         },
-            //     ],
-            // },
+            config: {
+                sendLibrary: '7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH',
+                receiveLibraryConfig: {
+                    receiveLibrary: '7a4WjyR8VZ7yZz5XJAKm39BUGn5iT9CKcv2pmG9tdXVH',
+                    gracePeriod: BigInt(0),
+                },
+                // Optional Receive Library Timeout for when the Old Receive Library Address will no longer be valid
+                // Note:  This configuring `receiveLibraryTimeoutConfig` using devtools is not currently available for Solana.
+                // receiveLibraryTimeoutConfig: {
+                //     lib: '0x0000000000000000000000000000000000000000',
+                //     expiry: BigInt(0),
+                // },
+                // Optional Send Configuration
+                // @dev Controls how the `from` chain sends messages to the `to` chain.
+                sendConfig: {
+                    executorConfig: {
+                        maxMessageSize: 10000,
+                        // The configured Executor address.  Note, this is the executor PDA not the program ID.
+                        executor: 'AwrbHeCyniXaQhiJZkLhgWdUCteeWSGaSN1sTfLiY7xK',
+                    },
+                    ulnConfig: {
+                        // // The number of block confirmations to wait on BSC before emitting the message from the source chain.
+                        confirmations: BigInt(10),
+                        // The address of the DVNs you will pay to verify a sent message on the source chain ).
+                        // The destination tx will wait until ALL `requiredDVNs` verify the message.
+                        requiredDVNs: [
+                            '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb', // LayerZero
+                        ],
+                        // The address of the DVNs you will pay to verify a sent message on the source chain ).
+                        // The destination tx will wait until the configured threshold of `optionalDVNs` verify a message.
+                        optionalDVNs: [],
+                        // The number of `optionalDVNs` that need to successfully verify the message for it to be considered Verified.
+                        optionalDVNThreshold: 0,
+                    },
+                },
+                // Optional Receive Configuration
+                // @dev Controls how the `from` chain receives messages from the `to` chain.
+                receiveConfig: {
+                    ulnConfig: {
+                        // The number of block confirmations to expect from the `to` chain.
+                        confirmations: BigInt(2),
+                        // The address of the DVNs your `receiveConfig` expects to receive verifications from on the `from` chain ).
+                        // The `from` chain's OApp will wait until the configured threshold of `requiredDVNs` verify the message.
+                        requiredDVNs: [
+                            '4VDjp6XQaxoZf5RGwiPU9NR1EXSZn2TP4ATMmiSzLfhb', // LayerZero
+                        ],
+                        // The address of the DVNs you will pay to verify a sent message on the source chain ).
+                        // The destination tx will wait until the configured threshold of `optionalDVNs` verify a message.
+                        optionalDVNs: [],
+                        // The number of `optionalDVNs` that need to successfully verify the message for it to be considered Verified.
+                        optionalDVNThreshold: 0,
+                    },
+                },
+                enforcedOptions: [
+                    {
+                        msgType: 1,
+                        optionType: ExecutorOptionType.LZ_RECEIVE,
+                        gas: 200000,
+                    },
+                    {
+                        msgType: 2,
+                        optionType: ExecutorOptionType.LZ_RECEIVE,
+                        gas: 200000,
+                    },
+                ],
+            },
         },
     ],
 }

--- a/examples/oft-solana/tasks/solana/createOFT.ts
+++ b/examples/oft-solana/tasks/solana/createOFT.ts
@@ -202,6 +202,7 @@ task('lz:oft:solana:create', 'Mints new SPL Token and creates new OFT Store acco
                     )
                 }
                 const createTokenTx = await txBuilder.sendAndConfirm(umi)
+                await new Promise((resolve) => setTimeout(resolve, 30000)) // Wait for 1 minute (60000 ms)
                 console.log(`createTokenTx: ${getExplorerTxLink(bs58.encode(createTokenTx.signature), isTestnet)}`)
             }
 


### PR DESCRIPTION
## How to run OFT-solana example

- git repo: https://github.com/LayerZero-Labs/devtools/tree/main/examples/oft-solana
- doc link: https://docs.layerzero.network/v2/developers/solana/oft/program

---

- copy the `examples/oft-solana` into its own folder, don’t do this in the `devtools` repo
- install dependencies
    - `pnpm install`
- compile the contract
    - `pnpm compile:hardhat`
- rename `.env.example` → `.env`
    - put the mnemonic of the test wallet
    - use `getBase58Pk.js` to generate `SOLANA_PRIVATE_KEY=4gLjZj53rsnTRVt5agJ4ESvE5ibgDhWM7yDJPU4qwVnZKQtAYM2kdBiZ3S1QYUbCqJMeTqzuaTc9Mnss3mWJKvEY`
- Prepare Program ID
    - `solana-keygen new -o target/deploy/endpoint-keypair.json --force`
    - `solana-keygen new -o target/deploy/oft-keypair.json --force`
    - `anchor keys sync`
    - change `program/src/oft/lib.rs` with new program id

```bash
endpoint: DHWHo6xdM2JbTS2Xy98tgbCsRjnEsQ9LJfXKGt7SXRWq
oft: 6KwN5yrcgpBLD6JLvtwng5qBu6XP9iHQ5JrEWy27KTX5
```

- build MyOFT program
    - `anchor build`
    - don’t add -v for verified build as its too slow
- deploy MyOFT program
    - `solana program deploy --program-id target/deploy/oft-keypair.json target/deploy/oft.so -u devnet`
- Create Solana OFT
    - `pnpm hardhat lz:oft:solana:create --eid 40168 --program-id 6KwN5yrcgpBLD6JLvtwng5qBu6XP9iHQ5JrEWy27KTX5 --only-oft-store true --name WooTestOFT --symbol WTOFT`
    - open `./deployments/solana-testnet/OFT.json` , find OFTStore = `FZL4iPCZm6QUcHNYz8Vfo5t9WNjbREjkuf6MT2RYu9Wq`
    - change `layerzero.config.ts` with `FZL4iPCZm6QUcHNYz8Vfo5t9WNjbREjkuf6MT2RYu9Wq`

```bash
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
No additional minters specified.  This will result in only the OFTStore being able to mint new tokens.
created SPL multisig @ 79cLxXpBokB4TG2ajQURy8hcsCFTAwGmACPSukzMboUo
createTokenTx: https://explorer.solana.com/tx/3Fer1ap4Nz1imxpws3XZpfXR5hHsoVUFP1g9Pbjb7F6Nd4TTbiyih5fJ7oUFWoWpySTeWaQWorcSRPeoKaVQ3un1?cluster=devnet
initOftTx: https://explorer.solana.com/tx/4Nj7YSdFiwvzSdh3cjgkfdmQQojYYNmSHZPbuHAtDUQVozTMoDDMY4nTg3NHJSxKCGNJwHmwS8mDAfLkgxXqbcHm?cluster=devnet
setAuthorityTx: https://explorer.solana.com/tx/2zhAg7pwXNHdyAAfjQcYbXuLeRC6gmVdWZemLTqCV6778Gv8XDwxs2D33ZdHEcA4bYsRazXeSha16D9iUMchw8Wn?cluster=devnet
Accounts have been saved to ./deployments/solana-testnet/OFT.json
```

- deploy the contract to Ethereum Sepolia
    - `npx hardhat lz:deploy`
    - tag use `MyOFT`
    - https://sepolia.etherscan.io/address/0xE3EBeC2Ce212eBdd0B9d31673198C4f306c152Ad#code

```bash
Network: sepolia-testnet
Deployer: 0xc031C368b51c28266396273b0C6ce2489b00969d
Deployed contract: MyOFT, network: sepolia-testnet, address: 0xE3EBeC2Ce212eBdd0B9d31673198C4f306c152Ad
info:    ✓ Your contracts are now deployed
```

- initialize the OFT
    - `npx hardhat lz:oapp:init:solana --oapp-config layerzero.config.ts --solana-secret-key 4gLjZj53rsnTRVt5agJ4ESvE5ibgDhWM7yDJPU4qwVnZKQtAYM2kdBiZ3S1QYUbCqJMeTqzuaTc9Mnss3mWJKvEY --solana-program-id 6KwN5yrcgpBLD6JLvtwng5qBu6XP9iHQ5JrEWy27KTX5`

```bash
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Endpoint            SOLANA_V2_TESTNET                                                                                                                                                                                                                                                                               │
│ OmniAddress         FZL4iPCZm6QUcHNYz8Vfo5t9WNjbREjkuf6MT2RYu9Wq                                                                                                                                                                                                                                                    │
│ OmniContract        -                                                                                                                                                                                                                                                                                               │
│ Function Name       -                                                                                                                                                                                                                                                                                               │
│ Function Arguments  -                                                                                                                                                                                                                                                                                               │
│ Description         oft.initConfig(40161)                                                                                                                                                                                                                                                                           │
│ Data                0100060923ddc3cd2307407c095913d0cd85671be7fef63a620ba2b8a4b6a1dafa13658520dd127e20d581954dffab6525efcdb0b1f61d558539c6cec090d5d9be166d4ea248bb8802ce01e0de886e8859b48aaa197e16d3cc0a345fa67b9993058604ab000000000000000000000000000000000000000000000000000000000000000016b7830c3f8a44c810ca87d │
│                     e56e032889c358ec75d4732bf7361862658acb2af3bb66c6947983775eb253df3d1c9818c2f958899b64a23b05a51bc8ed358f6e95aad76da514b6e1dcf11037e904dac3d375f525c9fbafcb19507b78907d8c18b619e429a1de67854bd455ee6643f568d6236cde8e9442a3abf029f016faae630cbc7cebfebaeb0ecb5dd6f629475ef1f8dd008f0305c17a8ef46c5 │
│                     eccbfddd65b5e217325e39378e5a4a13c4dc826c9cbb0e930e859eb79cf88c065da2eb37d201060a000805040700040201032c17eb73e8a86001e7d84bc2350d602488c1c2353e4234bb032cec29b2d968b650e5ce30c9b62d5132e19c0000                                                                                                  │
│ Value               -                                                                                                                                                                                                                                                                                               │
│ Gas Limit           -                                                                                                                                                                                                                                                                                               │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
✔ Would you like to submit the required transactions? … yes
info:    Successfully sent 1 transaction
info:    ✓ Your OApp is now configured
```

- wire the config
    - `npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts --solana-secret-key 4gLjZj53rsnTRVt5agJ4ESvE5ibgDhWM7yDJPU4qwVnZKQtAYM2kdBiZ3S1QYUbCqJMeTqzuaTc9Mnss3mWJKvEY --solana-program-id 6KwN5yrcgpBLD6JLvtwng5qBu6XP9iHQ5JrEWy27KTX`

## Test Sending

- Send from Sepolia to Solana devnet
    - `npx hardhat --network sepolia-testnet send --dst-eid 40168 --amount 1000000000000000000 --to 3R1QAWUwPNRunitwENqieRv3SS1BTpPTvhemJEuCeSZA`
    - Sepolia: https://sepolia.etherscan.io/tx/0x0a62fa41861529ac84b58705540dce71643d11ca15cafefa196a86294ce1c558
    - LayerZero: https://testnet.layerzeroscan.com/tx/0x0a62fa41861529ac84b58705540dce71643d11ca15cafefa196a86294ce1c558
    - Solana: https://explorer.solana.com/tx/2WVSAsxsw7asgTeKUQ8s6yB26zEJ5pgtWPEsstPL81s34LsLgxtsN2acq2LahutvLd5BZWiMTdQAUJBVLLxf9buw?cluster=devnet
    - WooTestOFT on Solana: https://explorer.solana.com/address/6ifJxvVPnFnwBgi8LCWyqT9tizSMEuD8DfSvxTkYjxs9?cluster=devnet

```bash
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
msgFee: 601683190102786
send: 1 to 3R1QAWUwPNRunitwENqieRv3SS1BTpPTvhemJEuCeSZA: 0x0a62fa41861529ac84b58705540dce71643d11ca15cafefa196a86294ce1c558
Track cross-chain transfer here: https://testnet.layerzeroscan.com/tx/0x0a62fa41861529ac84b58705540dce71643d11ca15cafefa196a86294ce1c558
```

- Send from Solana devnet to Sepolia
    - `npx hardhat lz:oft:solana:send --amount 1000000000 --from-eid 40168 --to 0xc031C368b51c28266396273b0C6ce2489b00969d --to-eid 40161 --mint 6ifJxvVPnFnwBgi8LCWyqT9tizSMEuD8DfSvxTkYjxs9 --program-id 6KwN5yrcgpBLD6JLvtwng5qBu6XP9iHQ5JrEWy27KTX5 --escrow PChaVffDRMyTxissMgBF3qSk8eYfq7YuZ78jhhqoHYx`
    - Solana: https://explorer.solana.com/tx/3B5vTUWs7WKCm1dV2B7RmPAZ6hAPt2vMdQL7nA2bWxoShhWoS8qBQGtzLWCrAgMnLJeTz5aAGvrCAnqo4TdgcLTJ?cluster=devnet
    - LayerZero: https://testnet.layerzeroscan.com/tx/3B5vTUWs7WKCm1dV2B7RmPAZ6hAPt2vMdQL7nA2bWxoShhWoS8qBQGtzLWCrAgMnLJeTz5aAGvrCAnqo4TdgcLTJ
    - Sepolia: https://sepolia.etherscan.io/tx/0x3b49feaaffce764e547b474a962650400a006114d13a0793216a938236ab6cdb

```bash
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
✅ Sent 1000000000 token(s) to destination EID: 40161!
View Solana transaction here: https://explorer.solana.com/tx/3B5vTUWs7WKCm1dV2B7RmPAZ6hAPt2vMdQL7nA2bWxoShhWoS8qBQGtzLWCrAgMnLJeTz5aAGvrCAnqo4TdgcLTJ?cluster=devnet
Track cross-chain transfer here: https://testnet.layerzeroscan.com/tx/3B5vTUWs7WKCm1dV2B7RmPAZ6hAPt2vMdQL7nA2bWxoShhWoS8qBQGtzLWCrAgMnLJeTz5aAGvrCAnqo4TdgcLTJ
```

## Debugging the error on receiver side

- https://scan-testnet.layerzero-api.com/v1/messages/tx/0x79bfff15f23ed6b309ee9f04321cb8a91f5b5515e32bb3e8396cc737620e9e03

![Xnip2024-11-25_20-11-24](https://github.com/user-attachments/assets/49971a95-c2af-4b2e-9d29-bd32d91f784f)


- you can find the error tx on Solana: https://solscan.io/tx/wqPf3tmMVd1SsqqEVN3sMChr7HZif96DgJTJxKLG4UvLBXhtrXHYB6j3XujQvALNk1xn1KKmfwoRnte9PtDXjne?cluster=devnet
- Lz endpoint receive tx: https://solscan.io/tx/4gnu9WCmZ2eN4F8ckrVMLGonM2hd1Hgnk5aWsiTd4Ntr8QJDnkcpsYfacrHmVFyGU2yLbj5wQoHutXrHftwwrd7E?cluster=devnet